### PR TITLE
Fix wrong enconding some title chapters

### DIFF
--- a/MNAVChapters/MNAVChapterReader.m
+++ b/MNAVChapters/MNAVChapterReader.m
@@ -292,7 +292,12 @@ long btoi(char* bytes, long size, long offset);
         NSData *titleData = SUBDATA(data, loc + ID3FrameFrame + ID3FrameEncoding, size - ID3FrameEncoding);
         result = [[NSString alloc] initWithBytes:titleData.bytes
                                           length:titleData.length
-                                        encoding:NSUTF16StringEncoding];
+                                        encoding:NSUTF8StringEncoding];
+        if (result == nil) {
+            result =[[NSString alloc] initWithBytes:titleData.bytes
+                                             length:titleData.length
+                                           encoding:NSUTF16StringEncoding];
+        }
     }
     @catch (NSException *exception) {
         //


### PR DESCRIPTION
Fixes a bug with some chapter titles that have a different encoding.

You can try with this audio file. You can show something like this:

chapter: 䥮瑲漀, (null), 0, 199975],
chapter: 却慲⁗慲猺⁅氠摥獰敲瑡爠摥⁬愠䙵敲穡, (null), 199975, 2588000],
chapter: 卥捣楯첁渠䝡浥爀, (null), 2787975, 925000],
chapter: 卵灥牨旌腲潥猠摥氠㈰ㄶ, (null), 3712975, 1163000],
chapter: 䍯湴慣瑯⁹⁤敳灥摩摡, (null), 4875975, 4290091295]

http://www.ivoox.com/1x01-el-despertar-punto-control_md_10438601_1.mp3?source=REFERER_DOWNLOAD&t=laikoZ6edqKupw%3D%3D
